### PR TITLE
feat(External-DNS): Add external-dns

### DIFF
--- a/clusters/main/kubernetes/core/external-dns/app/crds/dnsendpoint-crd.yaml
+++ b/clusters/main/kubernetes/core/external-dns/app/crds/dnsendpoint-crd.yaml
@@ -1,0 +1,97 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/external-dns/pull/2007
+    controller-gen.kubebuilder.io/version: v0.17.2
+  name: dnsendpoints.externaldns.k8s.io
+spec:
+  group: externaldns.k8s.io
+  names:
+    kind: DNSEndpoint
+    listKind: DNSEndpointList
+    plural: dnsendpoints
+    singular: dnsendpoint
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: |-
+            DNSEndpoint is a contract that a user-specified CRD must implement to be used as a source for external-dns.
+            The user-specified CRD should also have the status sub-resource.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: DNSEndpointSpec defines the desired state of DNSEndpoint
+              properties:
+                endpoints:
+                  items:
+                    description: Endpoint is a high-level way of a connection between a service and an IP
+                    properties:
+                      dnsName:
+                        description: The hostname of the DNS record
+                        type: string
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: Labels stores labels defined for the Endpoint
+                        type: object
+                      providerSpecific:
+                        description: ProviderSpecific stores provider specific config
+                        items:
+                          description: ProviderSpecificProperty holds the name and value of a configuration which is specific to individual DNS providers
+                          properties:
+                            name:
+                              type: string
+                            value:
+                              type: string
+                          type: object
+                        type: array
+                      recordTTL:
+                        description: TTL for the record
+                        format: int64
+                        type: integer
+                      recordType:
+                        description: RecordType type of record, e.g. CNAME, A, AAAA, SRV, TXT etc
+                        type: string
+                      setIdentifier:
+                        description: Identifier to distinguish multiple records with the same name and type (e.g. Route53 records with routing policies other than 'simple')
+                        type: string
+                      targets:
+                        description: The targets the DNS record points to
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  type: array
+              type: object
+            status:
+              description: DNSEndpointStatus defines the observed state of DNSEndpoint
+              properties:
+                observedGeneration:
+                  description: The generation observed by the external-dns controller.
+                  format: int64
+                  type: integer
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/clusters/main/kubernetes/core/external-dns/app/helm-release.yaml
+++ b/clusters/main/kubernetes/core/external-dns/app/helm-release.yaml
@@ -1,0 +1,55 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/refs/heads/main/helmrelease-helm-v2beta1.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: external-dns
+  namespace: external-dns
+spec:
+  interval: 15m
+  chart:
+    spec:
+      chart: external-dns
+      version: 7.3.2
+      sourceRef:
+        kind: HelmRepository
+        name: truecharts
+        namespace: flux-system
+      interval: 15m
+      reconcileStrategy: Revision
+  timeout: 20m
+  maxHistory: 3
+  install:
+    createNamespace: true
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  uninstall:
+    keepHistory: false
+  values:
+    externaldns:
+      logLevel: "info"
+      logFormat: "text"
+      interval: "60m"
+      provider: "pihole"
+      sources:
+        - "service"
+        - "ingress"
+        - "traefik-proxy"
+      domainFilters: []
+      zoneidFilters: []
+      registry: "noop"
+      policy: "upsert-only"  # would prevent ExternalDNS from deleting any records, omit to enable full synchronization
+      piholeServer: "http://${PIIP}"
+      piholePassword: "${PIKEY}"
+      piholeAPIVersion: "6"
+    workload:
+      main:
+        podSpec:
+          containers:
+            main:
+              env:
+                EXTERNAL_DNS_TRAEFIK_DISABLE_LEGACY: "true"

--- a/clusters/main/kubernetes/core/external-dns/app/kustomization.yaml
+++ b/clusters/main/kubernetes/core/external-dns/app/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - helm-release.yaml
+  - crds/dnsendpoint-crd.yaml

--- a/clusters/main/kubernetes/core/external-dns/app/namespace.yaml
+++ b/clusters/main/kubernetes/core/external-dns/app/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: external-dns
+  labels:
+    pod-security.kubernetes.io/enforce: privileged

--- a/clusters/main/kubernetes/core/external-dns/ks.yaml
+++ b/clusters/main/kubernetes/core/external-dns/ks.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: external-dns
+  namespace: flux-system
+spec:
+  interval: 10m
+  path: clusters/main/kubernetes/core/external-dns/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: cluster

--- a/clusters/main/kubernetes/core/kustomization.yaml
+++ b/clusters/main/kubernetes/core/kustomization.yaml
@@ -4,6 +4,7 @@ resources:
   - authelia/ks.yaml
   - blocky/ks.yaml
   - clusterissuer/ks.yaml
+  - external-dns/ks.yaml
   - generic-device-plugin/ks.yaml
   - lldap/ks.yaml
   - metallb-config/ks.yaml


### PR DESCRIPTION
# Manual Pull Request

## 🚀 Summary

Add External DNS to manage DNS records in PiHole and others as they come along and add a CRD for a troublesome ingress.

## 📦 Affected Areas

- [X] HelmRelease
- [ ] Kustomization
- [ ] Secrets (SOPS)
- [ ] Cluster Bootstrap / Repos
- [ ] Ingress
- [ ] Monitoring
- [ ] VolSync / Backups
- [ ] CI
- [ ] Other: <!-- Specify -->

---

## ✅ Checklist

- [ ] Secrets encrypted with SOPS and committed as encrypted only
- [ ] No plaintext secrets committed
- [ ] Base domain, hostnames, and URLs are templated correctly
- [ ] Certifcate issuer set correctly
- [X] Required Helm repositories are defined in `./repositories/helm`
- [ ] Integrations set correctly
- [X] Chart versions are correct vs upstream
- [ ] Ingress annotations and rules are correct
- [ ] Volsync setup correctly
- [X] Kustomizations reference correct chart and path
- [ ] CI workflows (if applicable) run successfully
- [X] Namespace is correct and consistent
- [X] Privileged setup where necessary

---

## 🧠 Notes for Myself

Look at a better way of doing CRDs!
