### PR TITLE
feat(mind-renovate): add mind-renovate

### DIFF
--- a/clusters/main/kubernetes/apps/kustomization.yaml
+++ b/clusters/main/kubernetes/apps/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
   - linkwarden/ks.yaml
   - mealie/ks.yaml
   - snippet-box/ks.yaml
+  - mend-renovate/ks.yaml

--- a/clusters/main/kubernetes/apps/mend-renovate/app/helm-release.yaml
+++ b/clusters/main/kubernetes/apps/mend-renovate/app/helm-release.yaml
@@ -1,0 +1,131 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: mend-renovate
+  namespace: mend-renovate
+spec:
+  interval: 15m
+  chart:
+    spec:
+      chart: mend-renovate
+      version: 4.3.2
+      sourceRef:
+        kind: HelmRepository
+        name: truecharts
+        namespace: flux-system
+      interval: 15m
+  timeout: 20m
+  maxHistory: 3
+  install:
+    createNamespace: true
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  uninstall:
+    keepHistory: false
+  values:
+    global:
+      stopAll: false
+    securityContext:
+      container:
+        readOnlyRootFilesystem: false
+        runAsNonRoot: false
+        runAsUser: 0
+        runAsGroup: 0
+    credentials:
+      s3:
+        type: s3
+        url: "${S3URL}"
+        bucket: "${S3PREFIX}-renovate"
+        accessKey: "${S3ID}"
+        secretKey: "${S3KEY}"
+        encrKey: "${S3KEY}"
+    service:
+      main:
+        type: ClusterIP
+        ports:
+          main:
+            port: 80
+    workload:
+      main:
+        podSpec:
+          containers:
+            main:
+              env:
+                MEND_RNV_SERVER_PORT: "{{ .Values.service.main.ports.main.port }}"
+                # Accept TOS required
+                MEND_RNV_ACCEPT_TOS: "Y"
+                # unregistered public license key
+                MEND_RNV_LICENSE_KEY: eyJsaW1pdCI6IjEwIn0=.30440220457941b71ea8eb345c729031718b692169f0ce2cf020095fd328812f4d7d5bc1022022648d1a29e71d486f89f27bdc8754dfd6df0ddda64a23155000a61a105da2a1
+                MEND_RNV_PLATFORM: github
+                # See https://github.com/mend/renovate-ce-ee/blob/main/docs/setup-for-github.md
+                MEND_RNV_GITHUB_APP_ID: "${MEND_RNV_GITHUB_APP_ID}"
+                MEND_RNV_WEBHOOK_SECRET: "${MEND_RNV_WEBHOOK_SECRET}"
+                # Mend Renovate Application settings (Optional)
+                MEND_RNV_SQLITE_FILE_PATH: "{{ .Values.persistence.db.mountPath }}/renovate-ce.sqlite"
+                MEND_RNV_LOG_HISTORY_DIR: "{{ .Values.persistence.logs.mountPath }}"
+                MEND_RNV_AUTODISCOVER_FILTER: "maverickd650/test-cluster"
+                # MEND_RNV_ENQUEUE_JOBS_ON_STARTUP: disabled  # Options: 'enabled', 'disabled', 'discovered' (default)
+              envFrom:
+                - secretRef:
+                    name: mend-renovate-secrets
+                    expandObjectName: false
+    ingress:
+      main:
+        enabled: true
+        ingressClassName: "traefik"
+        annotations:
+          traefik.ingress.kubernetes.io/router.entrypoints: websecure
+          traefik.ingress.kubernetes.io/router.tls: 'true'
+          traefik.ingress.kubernetes.io/router.middlewares: traefik-chain-basic@kubernetescrd
+        integrations:
+          certManager:
+            enabled: true
+            certificateIssuer: domain-0-le-prod
+        hosts:
+          - host: renovate.${DOMAIN_0}
+            paths:
+              - path: /
+                pathType: Prefix
+    gatus:
+      endpoints:
+        - name: mend-renovate
+          group: Infrastructure
+          url: "http://mend-renovate.mend-renovate.svc.cluster.local:80"
+          interval: 1m
+          ui:
+            hide-url: true
+            hide-hostname: true
+          conditions:
+            - "[CONNECTED] == true"
+          alerts:
+            - type: discord
+              description: "healthcheck failed"
+              send-on-resolved: true
+    configmap:
+      gatus:
+        enabled: true
+        labels:
+          gatus.io/enabled: "true"
+        data:
+          config.yaml: |
+            {{- $.Values.gatus | toYaml | nindent 2 }}
+    persistence:
+      db:
+        enabled: true
+        mountPath: /db
+        volsync:
+          - name: data
+            type: restic
+            credentials: s3
+            dest:
+              enabled: true
+            src:
+              enabled: true
+      logs:
+        enabled: true
+        mountPath: /logs

--- a/clusters/main/kubernetes/apps/mend-renovate/app/kustomization.yaml
+++ b/clusters/main/kubernetes/apps/mend-renovate/app/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - helm-release.yaml
+  - renovate.secret.yaml

--- a/clusters/main/kubernetes/apps/mend-renovate/app/namespace.yaml
+++ b/clusters/main/kubernetes/apps/mend-renovate/app/namespace.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: mend-renovate
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+  annotations:
+    volsync.backube/privileged-movers: "true"

--- a/clusters/main/kubernetes/apps/mend-renovate/app/renovate.secret.yaml
+++ b/clusters/main/kubernetes/apps/mend-renovate/app/renovate.secret.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: mend-renovate-secrets
+    namespace: mend-renovate
+type: Opaque
+stringData:
+    MEND_RNV_GITHUB_APP_KEY: ENC[AES256_GCM,data:Qegkm0q6lCCBHsoaYpl1jSHidORlTaayLhmmIYmOd323eA2QOoxR+s8t+/CPNzjXJKshK1kKwoNwHCdRkRXQY+mmr1a0YyzfcMyzAQNDt1+zJbHH6epImisxb5UyPVRxnVMpST909Ms78sIKLiHwqHtUyTaind6welaCwOQrEivNrc8y+5sIgw9IjM7edqV/LEnO1DereCS3AkD+D5ZgjMgoT8+inaWlvIwauHl6HBJ/8ax5/dQwCCsgsVczLxGgQXPUMz9uQJFBMT+Kxf9uNSu8usAJoD9dZTEnffTMPzKRrXLv8BtRFNOf0hhgOnlB3C/aVXppBDL8QY3aq4z/keyHSTjofDNfKD2P5HvUt7Im/hBDuymoZL+dbieEKmrXuPgYtxGMLV1+6ilLKJXG8KFrjzbVBwonTCkYa4DRwb8BtgaOQqATs1TVM+CB3ehEeYBLNcU6aV9YK7uicxz3fuU1QjKMTOGvePC5LD2hNpsrxLfVLlH4N6Vg+H/s6y0T2X/4HUtSpDzA9uFlq9bO3hpT3A0n+Tq4UsSIlnEevBZdIBamdjkt5MCm4vNGM9Kr4IKg7XKN3ynyxQQw/UxtpYZyHq0DUmTJ+H8XP60gKvV4gFIv6sMRn6SegmhgWOWZrUH5hXJLNgF2cHSzN8VuwkJ5Gkcon1YGN2BAJNTL0KE0gQpbYyQzB6moOdA64Q3v/crRGX4xJZsBzVj4KDeCIL0Fv5OBVNJhTsSBiOoAj+xQm17SMewk2E1yHlzmubyQftHW8940PDOS5wDkwGukN1OdcuIHfxPHKePN5USj7CZIYSANCp04THEzOPvVvi2F+3OY5pzkdemRIQe373Qw7i7zVZ2N+bkpTCpzAdRDrzaghX+k/bQgNs4AtqebotbpUEWGDaoXFheRqB588BawNJ4lxobvdODoQ2SNz0Dd/UY3NzXcJbQq9P3CgbyQt0s4pQRHEtUeuwa25hcLtN7ST8siDGUyY1oYcqXJXhVj+aR2Yq64cZ8Ubul5dCHHavEziXX5ekILcfqRgGdkRnz7bnVEBI4bbaLrh/1ypWQKJgYooO2834V9x+ANSNtOmuQaE+PeKNyYeF5up+X3Dl5JxM5c37Cck4NSlmZHzFUNFbQCbSk6Ixpyho3EtvXv3kuBJXbjA+wLxmOXwYjerUnlX5uxSTGbbUCDd5r3/osqx6nfUomdjfdtN80tosyeCDW0PAJ5Ln3qNiwOTdLkXaGsAWIMPBO2YVUYDjq2ajRwxmp8OW6b1uXHznHAkUM/nWdYnVVh77+V+3St5UOluClJfmGQOxo2/utZQ7pL0GdbQrHNeyk/CHd70DLD+Q4UW4aIMwDxDNzyv0bJZhXeb2D3QMQBURYO5HhLg/nfYQFMZezZXyKoH/JzwvnvZfV2D3Kk/54EAg8ffFndW9DTSWVObVsDYj7nDybHTxIIQi0Ymzjk863ylEvHp8j/KbiO6P0S/58U47of/12hhOso9gsdgU+r6a0JDb226aGJ/MMGmc/KNxW9iY/XsOabzH2KiMtUfb97AJQaiz/TdItG+zBNEHsRMVzszaO3Bk9sC3PTFjRZS2uUDVDx+g1Krx9TRDK6pVcT9OMPu5aKwoVK1FW5oWH4mR/vtZUzehpuJvnwv0r25yJNmyomTsJhyNTW8lTEfmeUw8MHMRu/q6y0bZ28noL14w7m5zSLnzq3n2qI57p/xq4fkJTeT8a/Xq7VBKLeugb61X3QB/7rUd3vCeR3YNdyoGz2Mjj44UvBVsIdHXKYvcEEK72N0q5L/5jtjb5rT7EBLZgeDmrQUByfl3XgB9jE1BrBWBRGHfBlwtoEhwtd/cl0PQUUrwGF0Z1NPIVuoHidUw0WZxR4JeCXEapMluEHGG/RY81gZgAs9RElVA0cj3maoBx28k/0T25wQ+QwNWeOgca87x7dr3TXYWkh4qqUaxnvPiwHVvzVRbVJUMwqjub6v1vzaZIcSqX5Acikg0/TDD06IiB6/J89w717+dzKFekL4jHdOIUR5bP7EwENfq4kAKT8M8wlofgZE4JT+qZfAegGRLtSZDOU88YZlrv5iwjQHauATTDjIEaUNeF7i8Ctqr/Pn4O0yB8Nhrc5CJZabWcWFkWdA4b17Cn/ADUQgXGYk2jwaLOZnfLRJzlWu9EY+ZaUEmFWCpmXV+eQNmUMxuGFqX435jZ8cHMda8K++oFhqSIoQ5yFyCb3iry5Rhr9ofH9UysLs2bQAbs=,iv:WhMmbA0tToB5F6aHAVZHS/+yfCP/Ai2A+/KHjz1bPHk=,tag:aXWozsL4ZTF2W+0gg+Miuw==,type:str]
+sops:
+    shamir_threshold: 3
+    age:
+        - recipient: age1zfv0dcgrmyqcnatthxn9qfnang6pk3hz96z93wyd792u8vncc3sqea5udt
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBDcERmVUMxYVZhekE5NnZk
+            d1FHZGN5OGxOdE1JNjJSeDRDTFVsWXNpT1dzClQ4M0piRzRwUFBtUStOVFFncjJR
+            L2p0WHNPSjFRRTk1YUxJc3VLNS9iK0EKLS0tIDZaR2lYbG56dm41Uit3dXgreVlT
+            eEZtYmFtOUc2aUYxN2FiNG9jNERxTWMK07/0jp9ylF+8yQtdhko+VPVN7Rw6eI5w
+            TZCsEA9wRgRsfJFf4BTRmcEJUkfhDYqRlBH9FXX/Thevl++ufp/YJQ==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2025-09-04T18:03:03Z"
+    mac: ENC[AES256_GCM,data:WnC18Qtjl04cVa2OKzDbZ7O2Tb1d4nIGKQHjJ+gCoGhnzeV4UAVmWiOtz5TvKlegHV8BTrhClizCzFK1jY7LaNAVSFuEW6XnvFfxhiX6rbI7ZeprVNgiLddtKZL0nDDo4bFt++OAJDVU+yn/hBuL/Dxe+nPpoPsRmTfCqeGhgJE=,iv:+gKAYvg46gc+eynXpTZE3PdU0cF1sPkDtGO36j/I3M0=,tag:qoVIvq3O6PfauuUiPn3jig==,type:str]
+    encrypted_regex: ((?i)(displayname|email|pass|ca|id|bootstraptoken|secretboxencryptionsecret|secrets|secrets|password|cert|secret($|[^N])|key|token|^data$|^stringData))
+    version: 3.10.2

--- a/clusters/main/kubernetes/apps/mend-renovate/ks.yaml
+++ b/clusters/main/kubernetes/apps/mend-renovate/ks.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: mend-renovate
+  namespace: flux-system
+spec:
+  interval: 10m
+  path: clusters/main/kubernetes/apps/mend-renovate/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: cluster


### PR DESCRIPTION
# Manual Pull Request

## 🚀 Summary
Add the mind-renovate chart for self hosted renovate.
<!-- Describe what you've changed and why. Be concise but clear. -->

## 📦 Affected Areas

- [X] HelmRelease
- [ ] Kustomization
- [X] Secrets (SOPS)
- [ ] Cluster Bootstrap / Repos
- [X] Ingress
- [ ] Monitoring
- [X] VolSync / Backups
- [ ] CI
- [ ] Other: <!-- Specify -->

---

## ✅ Checklist

- [X] Secrets encrypted with SOPS and committed as encrypted only
- [X] No plaintext secrets committed
- [X] Base domain, hostnames, and URLs are templated correctly
- [X] Certifcate issuer set correctly
- [X] Required Helm repositories are defined in `./repositories/helm`
- [X] Integrations set correctly
- [X] Chart versions are correct vs upstream
- [X] Ingress annotations and rules are correct
- [X] Volsync setup correctly
- [X] Kustomizations reference correct chart and path
- [ ] CI workflows (if applicable) run successfully
- [X] Namespace is correct and consistent
- [X] Privileged setup where necessary

---

## 🧠 Notes for Myself

<!-- Leave any reminders, notes, or follow-ups for future you here. -->
